### PR TITLE
fixed two flaky tests in dmestore-service

### DIFF
--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/VmfsAccessServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/VmfsAccessServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -1705,7 +1706,7 @@ public class VmfsAccessServiceImpl implements VmfsAccessService {
     private ResponseEntity hostUnmapping(Map<String, Object> params) throws DmeException {
         String hostId = ToolUtils.getStr(params.get(HOST_ID));
         Object volumeIds = params.get(VOLUMEIDS);
-        Map<String, Object> requestbody = new HashMap<>();
+        Map<String, Object> requestbody = new LinkedHashMap<>();
         requestbody.put(HOST_ID, hostId);
         requestbody.put(VOLUME_IDS, volumeIds);
         ResponseEntity responseEntity = dmeAccessService.access(DmeConstants.DME_HOST_UNMAPPING_URL, HttpMethod.POST,

--- a/dmestore-service/src/main/java/com/huawei/dmestore/services/VmfsOperationServiceImpl.java
+++ b/dmestore-service/src/main/java/com/huawei/dmestore/services/VmfsOperationServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -178,7 +179,7 @@ public class VmfsOperationServiceImpl implements VmfsOperationService {
 
     @Override
     public void expandVmfs(Map<String, String> volumemap) throws DmeException {
-        Map<String, Object> reqBody = new HashMap<>(DEFAULT_CAPACITY);
+        Map<String, Object> reqBody = new LinkedHashMap<>(DEFAULT_CAPACITY);
         List<String> volumeIds = new ArrayList<>(DEFAULT_CAPACITY);
 
         String volumeId = volumemap.get("volume_id");

--- a/dmestore-service/src/test/java/com/huawei/dmestore/services/VmfsAccessServiceTest.java
+++ b/dmestore-service/src/test/java/com/huawei/dmestore/services/VmfsAccessServiceTest.java
@@ -31,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -432,7 +433,7 @@ public class VmfsAccessServiceTest {
         String listStr1 = gson.toJson(clusters);
         when(vcsdkUtils.getMountClustersByDsObjectId(dataStoreId, mappeddmegroups)).thenReturn(listStr1);
         String unmappingUrl = "/rest/blockservice/v1/volumes/host-unmapping";
-        Map<String, Object> requestbody = new HashMap<>();
+        Map<String, Object> requestbody = new LinkedHashMap<>();
         requestbody.put("host_id", hostId);
         requestbody.put("volume_ids", volumeIds);
         ResponseEntity responseEntity1 = new ResponseEntity(taskStr, null, HttpStatus.ACCEPTED);


### PR DESCRIPTION
Fixed two flaky tests:
 1. `com.huawei.dmestore.services.VmfsAccessServiceTest.unmountVmfs`
 2. `com.huawei.dmestore.services.VmfsOperationServiceImplTest.expandVmfs`


### Description


To reproduce the problem, first build the module `dmestore-service`:
```shell
mvn install -pl dmestore-service -am -DskipTests
```

To identify the flaky tests, execute the following [nondex](https://github.com/TestingResearchIllinois/NonDex) command:
 ```shell
mvn -pl dmestore-service  edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.huawei.dmestore.services.VmfsAccessServiceTest#unmountVmfs  -DnondexRuns=10
```

and
 ```shell
mvn -pl dmestore-service  edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.huawei.dmestore.services.VmfsOperationServiceImplTest#expandVmfs -DnondexRuns=10
```


The two flaky tests both results from incorrect assumptions about the order of the requestbody implemented by HashMap.

The fix incorporates `LinkedHashMap` to replace `HashMap` to keep the order consistency.